### PR TITLE
Change precedence for config loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __pycache__/
 **/__pycache__/
 *.pyc
+.venv/

--- a/ufo/config/config.py
+++ b/ufo/config/config.py
@@ -12,16 +12,22 @@ def load_config(config_path="ufo/config/config.yaml"):
     :param config_path: The path to the YAML config file. Defaults to "./config.yaml".
     :return: Merged configuration from environment variables and YAML file.
     """
-    # Copy environment variables to avoid modifying them directly
-    configs = dict(os.environ)
+
+    configuration = dict()
 
     try:
         with open(config_path, "r") as file:
-            yaml_data = yaml.safe_load(file)
+            yaml_configuration = yaml.safe_load(file)
         # Update configs with YAML data
-        if yaml_data:
-            configs.update(yaml_data)
+        if yaml_configuration:
+            configuration.update(yaml_configuration)
+
     except FileNotFoundError:
         print(f"Warning: Config file not found at {config_path}. Using only environment variables.")
 
-    return configs
+    env_configuration = dict(os.environ)
+
+    # Override static file configuration with environment variables
+    configuration.update(env_configuration)
+
+    return configuration


### PR DESCRIPTION
Make environment variables override the configuration file instead of vice versa.

Rationale: things like API_KEY, if put into config, could accidentally be checked in, peeked at, etc., so putting them in environment variables instead is safer.